### PR TITLE
0.8.1.4 Preview Clean-up 🥨🧹

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: github-pages-production
+  group: github-pages-deployment
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -16,8 +16,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: github-pages-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: github-pages-deployment
+  cancel-in-progress: false
 
 jobs:
   deploy-preview:
@@ -29,6 +29,12 @@ jobs:
       - name: Check out repository
         if: github.event.action != 'closed'
         uses: actions/checkout@v5
+
+      - name: Check out repository for cleanup
+        if: github.event.action == 'closed'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Set up Node.js
         if: github.event.action != 'closed'


### PR DESCRIPTION
## Summary

- Fix PR preview cleanup after a pull request closes.
- Check out the repository during cleanup so the Pages deployment action can initialize Git.
- Serialize production and preview deployments to prevent concurrent `gh-pages` updates.

## Validation

- [x] Confirmed the PR 84 cleanup failure was caused by missing repository checkout.
- [x] Verified workflow formatting and cleanup configuration with `git diff --check`.
- [ ] Push the branch and rerun the PR 84 cleanup workflow.
- [ ] Confirm PR 84 is removed while PR 83 remains available.

Targets `development`; production content and existing open PR previews remain in scope.