### PR TITLE
0.8.0.11 🥨🥨 Add version display to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 	<!-- chord -->
 	<div class="chord">
 	</div>
+	<footer class="version" aria-label="application version">Version 0.8.0</footer>
 </body>
 
 <!-- methods -->

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -29,6 +29,12 @@ updateFile(
   badgeVersion
 );
 
+updateFile(
+  'index.html',
+  /Version [0-9A-Za-z.-]+(?=<\/footer>)/,
+  `Version ${version}`
+);
+
 packageJson.description = packageJson.description.replace(
   /Version-[0-9A-Za-z.-]+-brightgreen\.svg/,
   badgeVersion

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -23,6 +23,15 @@ body{
 	text-align: center;
 }
 
+.version{
+	color: var(--piano-white);
+	font-size: 16px;
+	font-weight: bold;
+	margin-top: 20px;
+	text-align: center;
+	opacity: 0.85;
+}
+
 #keyboard{
 	text-align: center;
     display: flex;


### PR DESCRIPTION

<img width="445" height="321" alt="image" src="https://github.com/user-attachments/assets/1ff37f14-df0b-45f0-86b4-47a9dd8d9ad2" />


## Summary 🐈

- Add a visible version footer to the app interface.
- Style the version label with the existing `--piano-white` variable.
- Synchronize the displayed version from `package.json` through the npm version script.

## Validation

- [x] `npm test` passed: 6 suites and 6 tests.
- [x] Coverage thresholds passed.
- [x] `npm run build` passed.
- [x] Version synchronization verified.
