### PR TITLE
fix: stabilize responsive layout 🥨

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -8,26 +8,36 @@ html{
 
 body{
 	margin: auto;
-    width: 50%;
+	width: min(500px, calc(100% - 20px));
 	padding: 10px;
 	margin-top: 25px;
+	box-sizing: border-box;
 }
 
 .chord{
 	color: var(--piano-white);
 	font-weight: bold;
-	text-align: center;
 	font-size: 50px;
-	height: 20%;
+	height: clamp(96px, 20vh, 140px);
+	min-height: 96px;
 	width: 100%;
 	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1.1;
+	overflow-wrap: anywhere;
+	padding: 0 8px;
+	box-sizing: border-box;
 }
 
 .version{
 	color: var(--piano-white);
 	font-size: 16px;
 	font-weight: bold;
-	margin-top: 20px;
+	line-height: 24px;
+	min-height: 24px;
+	margin: 0;
 	text-align: center;
 	opacity: 0.85;
 }
@@ -35,7 +45,7 @@ body{
 #keyboard{
 	text-align: center;
     display: flex;
-	width: 400px;
+	width: min(400px, 100%);
 	position: relative;
 	margin: auto;
 }
@@ -90,4 +100,30 @@ body{
 
 .right-corner{
 	border-radius: 0 10px 7px 7px;
+}
+
+@media (max-height: 480px){
+	body{
+		margin-top: 0;
+	}
+
+	.chord{
+		height: 64px;
+		min-height: 64px;
+		font-size: clamp(36px, 12vw, 50px);
+	}
+
+	.key.white{
+		height: 130px;
+	}
+
+	.key.black{
+		height: 72px;
+	}
+
+	.version{
+		font-size: 13px;
+		line-height: 20px;
+		min-height: 20px;
+	}
 }


### PR DESCRIPTION
### Pull Request Summary

#### Responsive Layout
- Reserve a stable chord-result area so the version footer does not move when chord values appear.
- Improve narrow-screen keyboard sizing and prevent horizontal and vertical overflow.
- Preserve the existing version styling and JavaScript behavior.

### Validation

- [x] `npm test`
- [x] `npm run build`
- [x] Desktop and mobile layout checks passed with no overlap or overflow.

Targets `development` and changes only the responsive layout styling.

### References
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/clamp
- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries/Using
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/calc
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/box-sizing
- https://playwright.dev/



<img width="395" height="439" alt="image" src="https://github.com/user-attachments/assets/dea7d9d6-714e-41bd-8dae-631e652d240a" />