### PR TITLE
test: add sound coverage & refactor 🧪🥨

### DIFF
--- a/src/js/sound.js
+++ b/src/js/sound.js
@@ -1,24 +1,21 @@
-// let preloaded = true
-
+// Preloads audio notes and provides functionality to play them
 function preload() {
-    let notes = []
-    _notes.forEach((element, index) => {
-        notes[index] = new Audio('src/sound/mp3/' + index + '.mp3')
-        notes[index].preload = true
+    return _notes.map((_, index) => {
+        const note = new Audio('src/sound/mp3/' + index + '.mp3')
+        note.preload = 'auto'  // Native HTML5 audio preload attribute
+        return note
     })
-    return notes
 }
 
-//plays note when pressed/clicked
+// Plays a specific note from the preloaded notes array
 function playNote(noteId, notes) {
     try {
-        notes[noteId].play()
-    }
-    catch (error) {
-        console.error(error)
+        notes[noteId].play()    // Attempt to play the specified note
+    } catch (error) {
+        console.error(error)    // Log the error if playback fails
     }
     return notes
 }
 
-exports.playNote = playNote
 exports.preload = preload
+exports.playNote = playNote

--- a/src/js/sound.test.js
+++ b/src/js/sound.test.js
@@ -1,0 +1,55 @@
+const sound = require('./sound.js')
+
+describe('playNote', () => {
+  test('plays the selected note and returns the notes array', () => {
+    const play = jest.fn()
+    const notes = [{ play }]
+
+    expect(sound.playNote(0, notes)).toBe(notes)
+    expect(play).toHaveBeenCalledTimes(1)
+  })
+
+  test('logs an error and returns the notes array when playback fails', () => {
+    const play = jest.fn(() => {
+      throw new Error('playback failed')
+    })
+    const notes = [{ play }]
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(sound.playNote(0, notes)).toBe(notes)
+    expect(consoleError).toHaveBeenCalledWith(expect.any(Error))
+
+    consoleError.mockRestore()
+  })
+})
+
+describe('preload', () => {
+  const originalAudio = global.Audio
+  let audioInstances
+
+  beforeEach(() => {
+    audioInstances = []
+    global.Audio = jest.fn(function (source) {
+      const audio = { source, preload: false }
+      audioInstances.push(audio)
+      return audio
+    })
+  })
+
+  afterEach(() => {
+    global.Audio = originalAudio
+  })
+
+  test('creates and configures an audio object for each note', () => {
+    const notes = sound.preload()
+
+    expect(global.Audio).toHaveBeenCalledTimes(_notes.length)
+    expect(notes).toHaveLength(_notes.length)
+    expect(audioInstances).toEqual(
+      _notes.map((note, index) => ({
+        source: `src/sound/mp3/${index}.mp3`,
+        preload: true
+      }))
+    )
+  })
+})

--- a/src/js/sound.test.js
+++ b/src/js/sound.test.js
@@ -44,12 +44,12 @@ describe('preload', () => {
   test('creates and configures an audio object for each note', () => {
     const notes = sound.preload() 
 
-    expect(global.Audio).toHaveBeenCalledTimes(notes.length)  // Ensure an audio object was created for each note
-    expect(notes).toHaveLength(notes.length)  // Ensure the returned notes array has the correct length
+    expect(global.Audio).toHaveBeenCalledTimes(_notes.length)  // Ensure an audio object was created for each note
+    expect(notes).toHaveLength(_notes.length)  // Ensure the returned notes array has the correct length
     expect(audioInstances).toEqual(
       _notes.map((note, index) => ({
         source: `src/sound/mp3/${index}.mp3`,
-        preload: true
+        preload: 'auto'
       }))
     )
   })

--- a/src/js/sound.test.js
+++ b/src/js/sound.test.js
@@ -47,7 +47,7 @@ describe('preload', () => {
     expect(global.Audio).toHaveBeenCalledTimes(_notes.length)  // Ensure an audio object was created for each note
     expect(notes).toHaveLength(_notes.length)  // Ensure the returned notes array has the correct length
     expect(audioInstances).toEqual(
-      _notes.map((note, index) => ({
+      _notes.map((_, index) => ({
         source: `src/sound/mp3/${index}.mp3`,
         preload: 'auto'
       }))

--- a/src/js/sound.test.js
+++ b/src/js/sound.test.js
@@ -1,31 +1,32 @@
-const sound = require('./sound.js')
+const sound = require('./sound.js') // Import the sound module for testing
 
 describe('playNote', () => {
   test('plays the selected note and returns the notes array', () => {
-    const play = jest.fn()
-    const notes = [{ play }]
+    const play = jest.fn()  // Mock function to simulate note playback
+    const notes = [{ play }]  // Array containing a single note with the mocked play function
 
     expect(sound.playNote(0, notes)).toBe(notes)
     expect(play).toHaveBeenCalledTimes(1)
   })
 
   test('logs an error and returns the notes array when playback fails', () => {
-    const play = jest.fn(() => {
+    const play = jest.fn(() => {  // Mock function that throws an error to simulate playback failure
       throw new Error('playback failed')
     })
     const notes = [{ play }]
+    // Spy on console.error to suppress error output during the test and verify it was called
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(sound.playNote(0, notes)).toBe(notes)
     expect(consoleError).toHaveBeenCalledWith(expect.any(Error))
 
-    consoleError.mockRestore()
+    consoleError.mockRestore()  // Restore the original console.error implementation after the test
   })
 })
 
 describe('preload', () => {
-  const originalAudio = global.Audio
-  let audioInstances
+  const originalAudio = global.Audio  // Store the original global Audio constructor to restore it after tests
+  let audioInstances  // Array to store instances of mocked audio objects
 
   beforeEach(() => {
     audioInstances = []
@@ -41,10 +42,10 @@ describe('preload', () => {
   })
 
   test('creates and configures an audio object for each note', () => {
-    const notes = sound.preload()
+    const notes = sound.preload() 
 
-    expect(global.Audio).toHaveBeenCalledTimes(_notes.length)
-    expect(notes).toHaveLength(_notes.length)
+    expect(global.Audio).toHaveBeenCalledTimes(notes.length)  // Ensure an audio object was created for each note
+    expect(notes).toHaveLength(notes.length)  // Ensure the returned notes array has the correct length
     expect(audioInstances).toEqual(
       _notes.map((note, index) => ({
         source: `src/sound/mp3/${index}.mp3`,


### PR DESCRIPTION
# Summary

Add Jest coverage and small refactoring for the sound module.

- Test successful note playback and playback errors.
- Test audio preloading and configuration.
- Use `map()` to create the preloaded audio array.
- Use the standard audio `preload` value, `auto`.

# Validation

- [x] Focused sound tests pass.
- [x] Full `npm test` passes.
- [x] Coverage remains at 100% statements, functions, and lines, with 95% branch coverage.

Related to #95.

# References

- https://jestjs.io/docs/mock-function-api
- https://jestjs.io/docs/mock-function-api#jestspiedsource
- https://jestjs.io/docs/mock-function-api#jestmockt
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplay_event
